### PR TITLE
up to 9.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ EXPOSE 5432
 # this dockerfile directly.
 ADD setup.sh /setup.sh
 RUN chmod 0755 /setup.sh
-RUN /setup.sh
+#RUN /setup.sh
 #login "docker" auto
 ADD .pgpass  /root/.pgpass
 RUN chmod 600 /root/.pgpass

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,15 @@ RUN gpg --keyserver pgpkeys.mit.edu --recv-key 7638D0442B90D010
 RUN gpg -a --export 7638D0442B90D010 | sudo apt-key add -
 RUN gpg --keyserver pgpkeys.mit.edu --recv-key 8B48AD6246925553
 RUN gpg -a --export 8B48AD6246925553 | sudo apt-key add -
+RUN gpg --keyserver pgpkeys.mit.edu --recv-key EF0F382A1A7B6500
+RUN gpg -a --export EF0F382A1A7B6500 | sudo apt-key add -
+
 RUN apt-get -y update
 RUN apt-get -y install ca-certificates rpl pwgen
 
 #-------------Application Specific Stuff ----------------------------------------------------
 
-RUN apt-get -t stretch install -y postgresql-9.6-postgis-2.3 netcat vim
+RUN sudo apt-get -t stretch install -y postgresql-9.6-postgis-2.3 netcat vim
 #ADD postgres.conf /etc/supervisor/conf.d/postgres.conf
 
 # Open port 5432 so linked containers can see them
@@ -33,7 +36,7 @@ EXPOSE 5432
 # this dockerfile directly.
 ADD setup.sh /setup.sh
 RUN chmod 0755 /setup.sh
-#RUN /setup.sh
+RUN /setup.sh
 #login "docker" auto
 ADD .pgpass  /root/.pgpass
 RUN chmod 600 /root/.pgpass

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get -y install ca-certificates rpl pwgen
 
 #-------------Application Specific Stuff ----------------------------------------------------
 
-RUN sudo apt-get -t stretch install -y postgresql-9.6-postgis-2.3 netcat vim
+RUN apt-get -t stretch install -y dialog postgresql-9.6-postgis-2.3 netcat vim
 #ADD postgres.conf /etc/supervisor/conf.d/postgres.conf
 
 # Open port 5432 so linked containers can see them

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y install ca-certificates rpl pwgen
 
 #-------------Application Specific Stuff ----------------------------------------------------
 
-RUN apt-get -t stretch install -y postgresql-9.5-postgis-2.2 netcat vim
+RUN apt-get -t stretch install -y postgresql-9.6-postgis-2.3 netcat vim
 #ADD postgres.conf /etc/supervisor/conf.d/postgres.conf
 
 # Open port 5432 so linked containers can see them

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can then go on to use any normal postgresql commands against the container.
 Under ubuntu 14.04 the postgresql client can be installed like this:
 
 ```
-sudo apt-get install postgresql-client-9.5
+sudo apt-get install postgresql-client-9.6
 ```
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,13 +2,13 @@
 chmod 600 /etc/ssl/private/ssl-cert-snakeoil.key
 
 # These tasks are run as root
-CONF="/etc/postgresql/9.5/main/postgresql.conf"
+CONF="/etc/postgresql/9.6/main/postgresql.conf"
 
 # Restrict subnet to docker private network
-echo "host    all             all             0.0.0.0/0               md5" >> /etc/postgresql/9.5/main/pg_hba.conf
+echo "host    all             all             0.0.0.0/0               md5" >> /etc/postgresql/9.6/main/pg_hba.conf
 # Listen on all ip addresses
-echo "listen_addresses = '*'" >> /etc/postgresql/9.5/main/postgresql.conf
-echo "port = 5432" >> /etc/postgresql/9.5/main/postgresql.conf
+echo "listen_addresses = '*'" >> /etc/postgresql/9.6/main/postgresql.conf
+echo "port = 5432" >> /etc/postgresql/9.6/main/postgresql.conf
 
 # Enable ssl
 


### PR DESCRIPTION
postgresql-9.5-postgis-2.2 no more available on strech repo.

to prevent this error 
```
E: Unable to locate package postgresql-9.5-postgis-2.2
E: Couldn't find any package by regex 'postgresql-9.5-postgis-2.2'
```
purpose to use postgresql-9.6-postgis-2.3 
(not test with lizmap/geoppopy)